### PR TITLE
Environment vars and auth link for quick Twitter account addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ diffengine.egg-info
 build
 Pip*
 .venv
+venv

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -673,6 +673,8 @@ def _get(url, allow_redirects=True):
 def add_rss():
     global home
     home = os.getcwd()
+    env_path = "%s/.env" % home
+    load_dotenv(dotenv_path=env_path)
     config = load_config(True)
 
     # Add new rss

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -391,9 +391,10 @@ def get_initial_config():
         if len(feed.entries) == 0:
             print("Oops, that doesn't look like an RSS or Atom feed.")
         else:
+            name = input("What is the name for this feed?")
             config['feeds'].append({
                 "url": url,
-                "name": feed.feed.title
+                "name": name if name == '' else feed.feed.title
             })
 
     answer = input("Would you like to set up tweeting edits? [Y/n] ")
@@ -669,10 +670,9 @@ def add_rss():
         return
 
     name = input("What is the name for this feed?")
-
     feed = {
         "url": url,
-        "name": name
+        "name": name if name == '' else feed.feed.title
     }
 
     twitter = config['twitter']

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -368,17 +368,16 @@ def setup_logging():
 def load_config(prompt=True):
     global config
     config_file = os.path.join(home, "config.yaml")
-    if os.path.isfile(config_file):
-        config = EnvYAML(config_file)
-    else:
+    if not os.path.isfile(config_file):
         if not os.path.isdir(home):
             os.makedirs(home)
         if prompt:
-            config = get_initial_config()
-        yaml.dump(config, open(config_file, "w"), default_flow_style=False)
-    return config
+            build_initial_config(config_file)
 
-def get_initial_config():
+    config = EnvYAML(config_file)
+
+
+def build_initial_config(config_file):
     config = {"feeds": []}
 
     while len(config['feeds']) == 0:
@@ -416,10 +415,11 @@ def get_initial_config():
             "access_token_secret": token[1]
         }
 
+    yaml.dump(config, open(config_file, "w"), default_flow_style=False)
     print("Saved your configuration in %s/config.yaml" % home.rstrip("/"))
     print("Fetching initial set of entries.")
 
-    return config
+
 
 def home_path(rel_path):
     return os.path.join(home, rel_path)
@@ -456,7 +456,7 @@ def setup_browser():
 
 
 def tweet_entry(entry, token):
-    if 'twitter' not in config:
+    if config.get('twitter', None) is None:
         logging.debug("twitter not configured")
         return
     elif not token:
@@ -482,7 +482,7 @@ def tweet_entry(entry, token):
 
 
 def tweet_diff(diff, token):
-    if 'twitter' not in config:
+    if config.get('twitter', None) is None:
         logging.debug("twitter not configured")
         return
     elif not token:

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -356,12 +356,20 @@ class Diff(BaseModel):
 def setup_logging():
     verbose = config.get('verbose', False)
     path = config.get('log', home_path('diffengine.log'))
+
+    format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    log_formatter = logging.Formatter(format)
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        format=format,
         filename=path,
         filemode="a"
     )
+
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(log_formatter)
+    logging.getLogger().addHandler(console_handler)
+
     logging.getLogger("readability.readability").setLevel(logging.WARNING)
     logging.getLogger("tweepy.binder").setLevel(logging.WARNING)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ jinja2
 peewee>=3.0
 pillow
 pytest
+python-dotenv>=0.13.0
 pyyaml>=5.1
 tweepy
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 bleach
+envyaml>=0.1912
+feedparser
 genshi
+-e https://github.com/edsu/htmldiff/tarball/master#egg=htmldiff-0.2
 jinja2
 peewee>=3.0
 pillow
 pytest
 python-dotenv>=0.13.0
-pyyaml>=5.1
-tweepy
+readability-lxml
 requests
 selenium
-feedparser
-readability-lxml
-https://github.com/edsu/htmldiff/tarball/master#egg=htmldiff-0.2
+tweepy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bleach
 envyaml>=0.1912
 feedparser
 genshi
--e https://github.com/edsu/htmldiff/tarball/master#egg=htmldiff-0.2
+https://github.com/edsu/htmldiff/tarball/master#egg=htmldiff-0.2
 jinja2
 peewee>=3.0
 pillow


### PR DESCRIPTION
The `config.yaml` now is integrated to env vars through "envyaml"

A new command `diffengine --auth` now returns the auth link for adding new feed twitter account easily