### PR TITLE
Configurable database

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,30 +88,31 @@ Logs can be found in `diffengine.log` in the storage directory, for example
 Checkout [Ryan Baumann's "diffengine" Twitter list] for a list of known
 diffengine Twitter accounts that are out there.
 
-## Tweeting text options
+## Config options
 
-By default, the tweeted diff will include the article's title and the archive diff url, [like this](https://twitter.com/mp_diff/status/1255973684994625539).
+### Database engine
 
-You change this by tweeting what's changed: the url, the title and/or the summary. For doing so, you need to specify **all** the following `lang` keys:
+By default the database is configured for Sqlite and the file `./diffengine.db` through the `db` config prop
 
 ```yaml
-lang:
-  change_in: "Change in"
-  the_url: "the URL"
-  the_title: "the title"
-  and: "and"
-  the_summary: "the summary"
+db: sqlite:///diffengine.db
 ```
 
-Only if all the keys are defined, the tweet will include what's changed on its content, followed by the `diff.url`. Some examples:
+This value responds to the [database URL connection string format](http://docs.peewee-orm.com/en/latest/peewee/playhouse.html#database-url).
 
-- "Change in the title"
-- "Change in the summary"
-- "Change in the title and the summary"
+For instance, you can co˚nnect to your postgresql database using something like this.
 
-And so on with all the possible combinations between url, title and summary
+```yaml
+db: postgresql://postgres:my_password@localhost:5432/my_database
+```
 
-## Multiple Accounts & Feed Implementation Example
+In case you store your database url connection into an environment var, like in Heroku. You can simply do as follows.
+
+```yaml
+db: "${DATABASE_URL}"
+```
+
+### Multiple Accounts & Feed Implementation Example
 
 If you are setting multiple accounts, and multiple feeds if may be helpful to setup a
 directory for each account. For example:
@@ -155,6 +156,29 @@ twitter:
   consumer_secret: CONSUMER_SECRET
 ```
 
+### Tweet content
+
+By default, the tweeted diff will include the article's title and the archive diff url, [like this](https://twitter.com/mp_diff/status/1255973684994625539).
+
+You change this by tweeting what's changed: the url, the title and/or the summary. For doing so, you need to specify **all** the following `lang` keys:
+
+```yaml
+lang:
+  change_in: "Change in"
+  the_url: "the URL"
+  the_title: "the title"
+  and: "and"
+  the_summary: "the summary"
+```
+
+Only if all the keys are defined, the tweet will include what's changed on its content, followed by the `diff.url`. Some examples:
+
+- "Change in the title"
+- "Change in the summary"
+- "Change in the title and the summary"
+
+And so on with all the possible combinations between url, title and summary
+
 ### Support for environment vars
 
 The configuration file has support for [environment variables](https://medium.com/chingu/an-introduction-to-environment-variables-and-how-to-use-them-f602f66d15fa). This is useful if you want to keeping your credentials secure when deploying to Heroku, Vercel (former ZEIT Now), AWS, Azure, Google Cloud or any other similar services. The environment variables are defined on the app of the platform you use or directly in a [dotenv file](https://12factor.net/config), which is the usual case when coding locally.
@@ -176,7 +200,7 @@ MY_CONSUMER_SECRET_ENV_VAR="CONSUMER_SECRET"
 
 Done! You can use diffengine as usual and keep your credentials safe.
 
-## Adding a Twitter account when the configuration file is already created
+### Adding a Twitter account when the configuration file is already created
 
 You can use the following command for adding Twitter accounts to the config file.
 

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -419,7 +419,7 @@ def setup_db():
 
     if isinstance(database_handler, SqliteDatabase):
         try:
-            migrator = SqliteMigrator(database)
+            migrator = SqliteMigrator(database_handler)
             migrate(migrator.add_index("entryversion", ("url",), False))
         except OperationalError as e:
             logging.debug(e)

--- a/diffengine/config.py
+++ b/diffengine/config.py
@@ -1,11 +1,10 @@
 import logging
 import os
-
 import feedparser
 import yaml
-from envyaml import EnvYAML
 
 from diffengine.utils import request_pin_to_user_and_get_token
+from envyaml import EnvYAML
 
 
 def load_config(home, prompt=True):

--- a/diffengine/config.py
+++ b/diffengine/config.py
@@ -1,0 +1,72 @@
+import logging
+import os
+
+import feedparser
+import yaml
+from envyaml import EnvYAML
+
+from diffengine.utils import request_pin_to_user_and_get_token
+
+
+def load_config(home, prompt=True):
+    config = {}
+    config_file = os.path.join(home, "config.yaml")
+    env_file = os.path.join(home, ".env")
+    if os.path.isfile(config_file):
+        logging.debug("config exists at file %s" % config_file)
+        config = EnvYAML(
+            config_file, env_file=env_file if os.path.isfile(env_file) else None
+        )
+    else:
+        logging.debug("creating config to file %s" % config_file)
+        if not os.path.isdir(home):
+            os.makedirs(home)
+        if prompt:
+            config = get_initial_config(home)
+        yaml.dump(config, open(config_file, "w"), default_flow_style=False)
+    return config
+
+
+def get_initial_config(home):
+    config = {"feeds": []}
+
+    while len(config["feeds"]) == 0:
+        url = input("What RSS/Atom feed would you like to monitor? ")
+        feed = feedparser.parse(url)
+        if len(feed.entries) == 0:
+            print("Oops, that doesn't look like an RSS or Atom feed.")
+        else:
+            config["feeds"].append({"url": url, "name": feed.feed.title})
+
+    answer = input("Would you like to set up tweeting edits? [Y/n] ") or "Y"
+    if answer.lower() == "y":
+        print("Go to https://apps.twitter.com and create an application.")
+        consumer_key = input("What is the consumer key? ")
+        consumer_secret = input("What is the consumer secret? ")
+
+        token = request_pin_to_user_and_get_token(consumer_key, consumer_secret)
+
+        config["twitter"] = {
+            "consumer_key": consumer_key,
+            "consumer_secret": consumer_secret,
+        }
+        config["feeds"][0]["twitter"] = {
+            "access_token": token[0],
+            "access_token_secret": token[1],
+        }
+
+    answer = input("Would you like to set up emailing edits? [Y/n] ")
+    if answer.lower() == "y":
+        print("Go to https://app.sendgrid.com/ and get an API key.")
+        api_key = input("What is the API key? ")
+        sender = input("What email address is sending the email? ")
+        receivers = input("Who are receiving the emails?  ")
+
+        config["sendgrid"] = {"api_key": api_key}
+
+        config["feeds"][0]["sendgrid"] = {"sender": sender, "receivers": receivers}
+
+    print("Saved your configuration in %s/config.yaml" % home.rstrip("/"))
+    print("Fetching initial set of entries.")
+
+    return config

--- a/diffengine/database.py
+++ b/diffengine/database.py
@@ -1,0 +1,34 @@
+import os
+
+from peewee import *
+from playhouse.migrate import SqliteMigrator, PostgresqlMigrator, migrate
+from playhouse.db_url import connect
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+if DATABASE_URL is not None:
+    print("defined database. Using PostgreSQL.")
+    db = connect(DATABASE_URL)
+else:
+    print("no database defined, using SQLite.")
+    db = SqliteDatabase(None)
+
+
+def setup_db():
+    global db
+
+    # If it's local, it needs to be init
+    if DATABASE_URL is None:
+        db_file = config.get("db", home_path("diffengine.db"))
+        logging.debug("connecting to db %s", db_file)
+        db.init(db_file)
+
+    db.connect()
+    db.create_tables([Feed, Entry, FeedEntry, EntryVersion, Diff], safe=True)
+
+    # If it's local, it needs to be init
+    if DATABASE_URL is None:
+        try:
+            migrator = SqliteMigrator(db)
+            migrate(migrator.add_index("entryversion", ("url",), False))
+        except OperationalError as e:
+            logging.debug(e)

--- a/diffengine/database.py
+++ b/diffengine/database.py
@@ -7,14 +7,14 @@ from playhouse.db_url import connect
 DATABASE_URL = os.getenv("DATABASE_URL")
 if DATABASE_URL is not None:
     print("defined database. Using PostgreSQL.")
-    db = connect(DATABASE_URL)
+    database = connect(DATABASE_URL)
 else:
     print("no database defined, using SQLite.")
-    db = SqliteDatabase(None)
+    database = SqliteDatabase(None)
 
 
 def setup_db():
-    global db
+    global database
 
     # If it's local, it needs to be init
     if DATABASE_URL is None:

--- a/diffengine/sendgrid.py
+++ b/diffengine/sendgrid.py
@@ -5,8 +5,8 @@ from sendgrid import Mail, SendGridAPIClient
 
 from exceptions.sendgrid import (
     AlreadyEmailedError,
-    ConfigNotFoundError,
-    ArchiveUrlNotFoundError,
+    SendgridConfigNotFoundError,
+    SendgridArchiveUrlNotFoundError,
 )
 
 
@@ -43,13 +43,13 @@ class SendgridHandler:
         if diff.emailed:
             raise AlreadyEmailedError(diff.id)
         elif not (diff.old.archive_url and diff.new.archive_url):
-            raise ArchiveUrlNotFoundError()
+            raise SendgridArchiveUrlNotFoundError()
 
         api_token = feed_config.get("api_token", self.api_token)
         sender = feed_config.get("sender", self.sender)
         receivers = feed_config.get("receivers", self.receivers)
         if not all([api_token, sender, receivers]):
-            raise ConfigNotFoundError
+            raise SendgridConfigNotFoundError
 
         subject = self.build_subject(diff)
         message = Mail(

--- a/diffengine/twitter.py
+++ b/diffengine/twitter.py
@@ -6,9 +6,9 @@ from datetime import datetime
 from diffengine.text_builder import build_text
 from exceptions.twitter import (
     AlreadyTweetedError,
-    ConfigNotFoundError,
+    TwitterConfigNotFoundError,
     TokenNotFoundError,
-    AchiveUrlNotFoundError,
+    TwitterAchiveUrlNotFoundError,
     UpdateStatusError,
 )
 
@@ -19,7 +19,7 @@ class TwitterHandler:
 
     def __init__(self, consumer_key, consumer_secret):
         if not consumer_key or not consumer_secret:
-            raise ConfigNotFoundError()
+            raise TwitterConfigNotFoundError()
 
         self.consumer_key = consumer_key
         self.consumer_secret = consumer_secret
@@ -59,7 +59,7 @@ class TwitterHandler:
         elif diff.tweeted:
             raise AlreadyTweetedError(diff)
         elif not (diff.old.archive_url and diff.new.archive_url):
-            raise AchiveUrlNotFoundError(diff)
+            raise TwitterAchiveUrlNotFoundError(diff)
 
         twitter = self.api(token)
         text = build_text(diff, lang)

--- a/diffengine/utils.py
+++ b/diffengine/utils.py
@@ -1,4 +1,6 @@
+import os
 import tweepy
+import yaml
 
 
 def request_pin_to_user_and_get_token(consumer_key, consumer_secret):
@@ -11,3 +13,12 @@ def request_pin_to_user_and_get_token(consumer_key, consumer_secret):
     input("Visit %s in your browser and hit enter." % auth_url)
     pin = input("What is your PIN: ")
     return auth.get_access_token(verifier=pin)
+
+
+def generate_config(home, content):
+    config_file = os.path.join(home, "config.yaml")
+
+    if not os.path.isdir(home):
+        os.makedirs(home)
+
+    yaml.dump(content, open(config_file, "w"), default_flow_style=False)

--- a/diffengine/utils.py
+++ b/diffengine/utils.py
@@ -1,0 +1,13 @@
+import tweepy
+
+
+def request_pin_to_user_and_get_token(consumer_key, consumer_secret):
+    auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
+    auth.secure = True
+    auth_url = auth.get_authorization_url()
+    input(
+        "Log in to https://twitter.com as the user you want to tweet as and hit enter."
+    )
+    input("Visit %s in your browser and hit enter." % auth_url)
+    pin = input("What is your PIN: ")
+    return auth.get_access_token(verifier=pin)

--- a/exceptions/sendgrid.py
+++ b/exceptions/sendgrid.py
@@ -2,7 +2,7 @@ class SendgridError(RuntimeError):
     pass
 
 
-class ConfigNotFoundError(SendgridError):
+class SendgridConfigNotFoundError(SendgridError):
     """Exception raised if the Sendgrid instance has not the API key"""
 
     def __init__(self):
@@ -14,6 +14,6 @@ class AlreadyEmailedError(SendgridError):
         self.message = "diff %s was already emailed with sendgrid " % diff_id
 
 
-class ArchiveUrlNotFoundError(SendgridError):
+class SendgridArchiveUrlNotFoundError(SendgridError):
     def __init__(self):
         self.message = "not publishing without archive urls"

--- a/exceptions/twitter.py
+++ b/exceptions/twitter.py
@@ -2,7 +2,7 @@ class TwitterError(RuntimeError):
     pass
 
 
-class ConfigNotFoundError(TwitterError):
+class TwitterConfigNotFoundError(TwitterError):
     """Exception raised if the Twitter instance has not the required key and secret"""
 
     def __init__(self):
@@ -21,7 +21,7 @@ class AlreadyTweetedError(TwitterError):
         self.message = "diff %s has already been tweeted" % diff.id
 
 
-class AchiveUrlNotFoundError(TwitterError):
+class TwitterAchiveUrlNotFoundError(TwitterError):
     def __init__(self, diff):
         self.message = "not tweeting without archive urls for diff %s" % diff.id
 

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -1,14 +1,12 @@
 import logging
 import os
 import re
-
 import yaml
-from selenium import webdriver
-
 import setup
 import pytest
 import shutil
 
+from selenium import webdriver
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from unittest.mock import PropertyMock
@@ -19,8 +17,6 @@ from diffengine import (
     EntryVersion,
     Entry,
     FeedEntry,
-    home_path,
-    load_config,
     setup_browser,
     UnknownWebdriverError,
     process_entry,
@@ -28,12 +24,13 @@ from diffengine import (
     TwitterHandler,
     SendgridHandler,
 )
+from diffengine.config import load_config
+from diffengine.text_builder import build_text
 from exceptions.sendgrid import (
     ConfigNotFoundError as SGConfigNotFoundError,
     AlreadyEmailedError as SGAlreadyEmailedError,
     ArchiveUrlNotFoundError as SGArchiveNotFoundError,
 )
-from diffengine.text_builder import build_text
 from exceptions.twitter import (
     ConfigNotFoundError,
     TokenNotFoundError,
@@ -179,7 +176,7 @@ class EnvVarsTest(TestCase):
         private_value = "private value"
 
         # create dot env that that will read
-        dotenv_file = open(home_path(".env"), "w+")
+        dotenv_file = open(os.path.join(test_home, ".env"), "w+")
         dotenv_file.write("PRIVATE_VAR=%s\n" % private_value)
         dotenv_file.close()
 
@@ -187,7 +184,7 @@ class EnvVarsTest(TestCase):
         test_config = {
             "example": {"private_value": private_yaml_key, "public_value": public_value}
         }
-        config_file = home_path("config.yaml")
+        config_file = os.path.join(test_home, "config.yaml")
         yaml.dump(test_config, open(config_file, "w"), default_flow_style=False)
 
         # test!

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -46,7 +46,8 @@ if os.path.isdir("test"):
     shutil.rmtree("test")
 
 # set things up but disable prompting for initial feed
-init("test", prompt=False)
+test_home = "test"
+init(test_home, prompt=False)
 
 # the sequence of these tests is significant
 
@@ -190,7 +191,7 @@ class EnvVarsTest(TestCase):
         yaml.dump(test_config, open(config_file, "w"), default_flow_style=False)
 
         # test!
-        new_config = load_config()
+        new_config = load_config(test_home)
         assert new_config["example"]["public_value"] == public_value
         assert new_config["example"]["private_value"] != private_yaml_key
         assert new_config["example"]["private_value"] == private_value

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -23,6 +23,7 @@ from diffengine import (
     UA,
     TwitterHandler,
     SendgridHandler,
+    _fingerprint,
 )
 from diffengine.config import load_config
 from diffengine.text_builder import build_text
@@ -45,130 +46,125 @@ test_home = "test"
 if os.path.isdir(test_home):
     shutil.rmtree(test_home)
 
-generate_config(test_home, {"db": "sqlite:///:memory:"})
-# set things up but disable prompting for initial feed
-init(test_home, prompt=False)
-
-# the sequence of these tests is significant
-
 
 def test_version():
     assert setup.version in UA
 
 
-def test_feed():
-    f = Feed.create(name="Test", url="https://inkdroid.org/feed.xml")
-    f.get_latest()
-    assert f.created
-    assert len(f.entries) == 10
-
-
-def test_entry():
-    f = Feed.get(Feed.url == "https://inkdroid.org/feed.xml")
-    e = f.entries[0]
-    v = e.get_latest()
-    assert type(v) == EntryVersion
-    assert len(e.versions) == 1
-
-
-def test_diff():
-    f = Feed.get(Feed.url == "https://inkdroid.org/feed.xml")
-    e = f.entries[0]
-    v1 = e.versions[0]
-
-    # remove some characters from the version
-    v1.summary = v1.summary[0:-20]
-    v1.save()
-
-    v2 = e.get_latest()
-    assert type(v2) == EntryVersion
-    assert v2.diff
-    assert v2.archive_url is not None
-    assert (
-        re.match("^https://web.archive.org/web/[0-9]+/.+$", v2.archive_url) is not None
-    )
-
-    diff = v2.diff
-    assert diff.old == v1
-    assert diff.new == v2
-    assert os.path.isfile(diff.html_path)
-    assert os.path.isfile(diff.screenshot_path)
-    assert os.path.isfile(diff.thumbnail_path)
-
-    # check that the url for the internet archive diff is working
-    assert re.match("^https://web.archive.org/web/diff/\d+/\d+/https.+$", diff.url)
-
-
-def test_html_diff():
-    f = Feed.get(Feed.url == "https://inkdroid.org/feed.xml")
-    e = f.entries[0]
-
-    # add a change to the summary that htmldiff ignores
-    v1 = e.versions[-1]
-    parts = v1.summary.split()
-    parts.insert(2, "<br>   \n")
-    v1.summary = " ".join(parts)
-    v1.save()
-
-    v2 = e.get_latest()
-    assert v2 is None
-
-
-def test_many_to_many():
-
-    # these two feeds share this entry, we want diffengine to support
-    # multiple feeds for the same content, which is fairly common at
-    # large media organizations with multiple topical feeds
-    url = "https://www.washingtonpost.com/classic-apps/how-a-week-of-tweets-by-trump-stoked-anxiety-moved-markets-and-altered-plans/2017/01/07/38be8e64-d436-11e6-9cb0-54ab630851e8_story.html"
-
-    f1 = Feed.create(
-        name="feed1",
-        url="https://raw.githubusercontent.com/DocNow/diffengine/master/test-data/feed1.xml",
-    )
-    f1.get_latest()
-
-    f2 = Feed.create(
-        name="feed2",
-        url="https://raw.githubusercontent.com/DocNow/diffengine/master/test-data/feed2.xml",
-    )
-    f2.get_latest()
-
-    assert f1.entries.where(Entry.url == url).count() == 1
-    assert f2.entries.where(Entry.url == url).count() == 1
-
-    e = Entry.get(Entry.url == url)
-    assert FeedEntry.select().where(FeedEntry.entry == e).count() == 2
-
-
-def test_bad_feed_url():
-    # bad feed url shouldn't cause a fatal exception
-    f = Feed.create(name="feed1", url="http://example.org/feedfeed.xml")
-    f.get_latest()
-    assert True
-
-
-def test_whitespace():
-    f = Feed.get(url="https://inkdroid.org/feed.xml")
-    e = f.entries[0]
-    v1 = e.versions[-1]
-
-    # add some whitespace
-    v1.summary = v1.summary + "\n\n    "
-    v1.save()
-
-    # whitespace should not count when diffing
-    v2 = e.get_latest()
-    assert v2 == None
-
-
 def test_fingerprint():
-    from diffengine import _fingerprint
-
     assert _fingerprint("foo bar") == "foobar"
     assert _fingerprint("foo bar\nbaz") == "foobarbaz"
     assert _fingerprint("foo<br>bar") == "foobar"
     assert _fingerprint("foo'bar") == "foobar"
     assert _fingerprint("foo’bar") == "foobar"
+
+
+class FeedTest(TestCase):
+    feed = None
+    entry = None
+    version = None
+
+    def setUp(self) -> None:
+        generate_config(test_home, {"db": "sqlite:///:memory:"})
+        # set things up but disable prompting for initial feed
+        init(test_home, prompt=False)
+        self.feed = Feed.create(name="Test", url="https://inkdroid.org/feed.xml")
+        self.feed.get_latest()
+        self.entry = self.feed.entries[0]
+        self.version = self.entry.get_latest()
+
+    def test_feed(self):
+        assert self.feed.created
+        assert len(self.feed.entries) == 10
+
+    def test_entry(self):
+        assert type(self.version) == EntryVersion
+        assert len(self.entry.versions) == 1
+
+    def test_diff(self):
+        e = self.entry
+        v1 = e.versions[0]
+
+        # remove some characters from the version
+        v1.summary = v1.summary[0:-20]
+        v1.save()
+
+        v2 = e.get_latest()
+        assert type(v2) == EntryVersion
+        assert v2.diff
+        assert v2.archive_url is not None
+        assert (
+            re.match("^https://web.archive.org/web/[0-9]+/.+$", v2.archive_url)
+            is not None
+        )
+
+        diff = v2.diff
+        assert diff.old == v1
+        assert diff.new == v2
+        assert os.path.isfile(diff.html_path)
+        assert os.path.isfile(diff.screenshot_path)
+        assert os.path.isfile(diff.thumbnail_path)
+
+        # check that the url for the internet archive diff is working
+        assert re.match(
+            "^https://web.archive.org/web/diff/\\d+/\\d+/https.+$", diff.url
+        )
+
+    def test_html_diff(self):
+        e = self.entry
+
+        # add a change to the summary that htmldiff ignores
+        v1 = e.versions[-1]
+        parts = v1.summary.split()
+        parts.insert(2, "<br>   \n")
+        v1.summary = " ".join(parts)
+        v1.save()
+
+        v2 = e.get_latest()
+        assert v2 is None
+
+    def test_many_to_many(self):
+
+        # these two feeds share this entry, we want diffengine to support
+        # multiple feeds for the same content, which is fairly common at
+        # large media organizations with multiple topical feeds
+        url = "https://www.washingtonpost.com/classic-apps/how-a-week-of-tweets-by-trump-stoked-anxiety-moved-markets-and-altered-plans/2017/01/07/38be8e64-d436-11e6-9cb0-54ab630851e8_story.html"
+
+        f1 = Feed.create(
+            name="feed1",
+            url="https://raw.githubusercontent.com/DocNow/diffengine/master/test-data/feed1.xml",
+        )
+        f1.get_latest()
+
+        f2 = Feed.create(
+            name="feed2",
+            url="https://raw.githubusercontent.com/DocNow/diffengine/master/test-data/feed2.xml",
+        )
+        f2.get_latest()
+
+        assert f1.entries.where(Entry.url == url).count() == 1
+        assert f2.entries.where(Entry.url == url).count() == 1
+
+        e = Entry.get(Entry.url == url)
+        assert FeedEntry.select().where(FeedEntry.entry == e).count() == 2
+
+    def test_bad_feed_url(self):
+        # bad feed url shouldn't cause a fatal exception
+        f = Feed.create(name="feed1", url="http://example.org/feedfeed.xml")
+        f.get_latest()
+        assert True
+
+    def test_whitespace(self):
+        e = self.feed.entries[0]
+        v1 = e.versions[-1]
+
+        # add some whitespace
+        v1.summary = v1.summary + "\n\n    "
+        v1.save()
+
+        # whitespace should not count when diffing
+        v2 = e.get_latest()
+        assert v2 == None
 
 
 class EnvVarsTest(TestCase):


### PR DESCRIPTION
**IMPORTANT. Do not merge yet. I'll be testing this in the real world today**

Now the database connection is handled with the `db` property directly and using URL database connections. If no `db` prop is defined, the value `sqlite:///diffengine.db` is used in order to maintain compatibility.

With this method, you can use MySQL, PostgreSQL or any other engine supported by peewee.
More info about [database url connections here](http://docs.peewee-orm.com/en/latest/peewee/playhouse.html#database-url)

### Non related

I've create a suite for the feed tests and I've independizate them as well for easier testing