### PR TITLE
Encoding autodetection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Pip*
 .env
 venv
 .idea
+*.ignore.py

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -24,6 +24,7 @@ import readability
 import unicodedata
 
 from diffengine.sendgrid import SendgridHandler
+from diffengine.text import to_utf8
 from diffengine.twitter import TwitterHandler
 
 from exceptions.webdriver import UnknownWebdriverError
@@ -173,8 +174,7 @@ class Entry(BaseModel):
         if resp.status_code != 200:
             logging.warn("Got %s when fetching %s", resp.status_code, self.url)
             return None
-
-        doc = readability.Document(resp.text)
+        doc = readability.Document(to_utf8(resp.text))
         title = doc.title()
         summary = doc.summary(html_partial=True)
         summary = bleach.clean(summary, tags=["p"], strip=True)

--- a/diffengine/text.py
+++ b/diffengine/text.py
@@ -58,3 +58,17 @@ def build_with_default_content(diff):
         text = text[0:225] + "…"
     text += " " + diff.url
     return text
+
+
+def to_utf8(text):
+    for encoding in ["latin1", "ascii"]:
+        try:
+            result = text.encode(encoding).decode("utf8", "strict")
+            break
+        except (UnicodeEncodeError, UnicodeDecodeError):
+            result = None
+
+    if result is None:
+        return text
+
+    return result

--- a/diffengine/twitter.py
+++ b/diffengine/twitter.py
@@ -3,7 +3,7 @@ import tweepy
 
 from datetime import datetime
 
-from diffengine.text_builder import build_text
+from diffengine.text import build_text
 from exceptions.twitter import (
     AlreadyTweetedError,
     TwitterConfigNotFoundError,

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -29,7 +29,7 @@ from diffengine import (
     SendgridHandler,
     _fingerprint,
 )
-from diffengine.text_builder import build_text
+from diffengine.text import build_text, to_utf8
 from diffengine.utils import generate_config
 from exceptions.sendgrid import (
     SendgridConfigNotFoundError,
@@ -804,3 +804,16 @@ class TextBuilderTest(TestCase):
         self.assertEqual(
             text, "change in the URL, the title and the summary\n%s" % diff.url
         )
+
+
+class EncodingTest(TestCase):
+    def test_utf8_do_nothingg(self):
+        text_utf8 = "Me preocupa más la parte futbolística"
+        result = to_utf8(text_utf8)
+        self.assertEquals(result, text_utf8)
+
+    def test_latin1_to_utf8(self):
+        text_latin = "Me preocupa mÃ¡s la parte futbolÃ­stica"
+        text_utf8 = "Me preocupa más la parte futbolística"
+        result = to_utf8(text_latin)
+        self.assertEquals(result, text_utf8)

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -663,8 +663,8 @@ def get_mocked_diff(with_archive_urls=True):
 
 class TextBuilderTest(TestCase):
     @patch("logging.warning")
-    @patch("diffengine.text_builder.build_with_lang")
-    @patch("diffengine.text_builder.build_with_default_content")
+    @patch("diffengine.text.build_with_lang")
+    @patch("diffengine.text.build_with_default_content")
     def test_build_with_default_content_when_no_lang_given(
         self, mocked_build_with_default_content, mocked_build_from_lang, mocked_warning
     ):
@@ -679,8 +679,8 @@ class TextBuilderTest(TestCase):
         mocked_build_from_lang.assert_not_called()
 
     @patch("logging.warning")
-    @patch("diffengine.text_builder.build_with_lang")
-    @patch("diffengine.text_builder.build_with_default_content")
+    @patch("diffengine.text.build_with_lang")
+    @patch("diffengine.text.build_with_default_content")
     def test_build_with_default_content_when_lang_is_incomplete(
         self, mocked_build_with_default_content, mocked_build_from_lang, mocked_warning
     ):
@@ -700,8 +700,8 @@ class TextBuilderTest(TestCase):
         mocked_build_from_lang.assert_not_called()
 
     @patch("logging.warning")
-    @patch("diffengine.text_builder.build_with_lang")
-    @patch("diffengine.text_builder.build_with_default_content")
+    @patch("diffengine.text.build_with_lang")
+    @patch("diffengine.text.build_with_default_content")
     def test_build_with_lang_when_lang_given(
         self, mocked_build_with_default_content, mocked_build_from_lang, mocked_warning
     ):
@@ -722,7 +722,7 @@ class TextBuilderTest(TestCase):
         mocked_build_with_default_content.assert_not_called()
         mocked_build_from_lang.assert_called_once()
 
-    @patch("diffengine.text_builder.build_with_lang")
+    @patch("diffengine.text.build_with_lang")
     def test_default_content_text(self, mocked_build_from_lang):
         diff = get_mocked_diff()
         type(diff.new).title = "Test"


### PR DESCRIPTION
Now if the page has latin1 or ascii chars, they're auto decoded to UTF-8.

This ensures a better version comparison and it avoids tweeting changes when the actual change is the encoding (happens a lot with https://twitter.com/mp_diff). For example [this tweet](https://twitter.com/mp_diff/status/1265410136815828992)